### PR TITLE
fix: render release notes as plain text

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepseek-harness-desktop",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "DeepSeek Harness 原生桌面启动器",
   "author": "MichengAI",
   "desktopName": "DSH Codex Desktop",

--- a/src/desktop-updater.ts
+++ b/src/desktop-updater.ts
@@ -38,6 +38,38 @@ export function desktopUpdatePrompt(status: Extract<DesktopUpdateStatus, { kind:
   return `发现桌面端 ${status.version}。\n\n${DESKTOP_UPDATE_WARNING}${notes}`
 }
 
+/** 原生系统对话框不渲染 HTML 或 Markdown，发布说明统一转为可读文本。 */
+export function formatDesktopReleaseNotes(notes: string | Array<{ note?: string | null }> | null | undefined): string | undefined {
+  const source = typeof notes === 'string'
+    ? notes
+    : Array.isArray(notes)
+      ? notes.map(item => item.note ?? '').join('\n')
+      : ''
+  const text = source
+    .replace(/\r\n?/g, '\n')
+    .replace(/<\s*br\s*\/?\s*>/gi, '\n')
+    .replace(/<\/\s*(?:p|div|section|article|h[1-6])\s*>/gi, '\n\n')
+    .replace(/<\s*li\b[^>]*>/gi, '- ')
+    .replace(/<\/\s*li\s*>/gi, '\n')
+    .replace(/<\/\s*(?:ul|ol)\s*>/gi, '\n')
+    .replace(/<\/?[a-z][^>]*>/gi, '')
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;|&apos;/gi, "'")
+    .replace(/^\s{0,3}#{1,6}\s+/gm, '')
+    .replace(/\[([^\]\n]+)\]\((https?:\/\/[^\s)]+)\)/g, '$1: $2')
+    .replace(/\*\*|__|`/g, '')
+    .replace(/^>\s?/gm, '')
+    .replace(/^\s*[-*+]\s+/gm, '- ')
+    .replace(/[ \t]+\n/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim()
+  return text === '' ? undefined : text
+}
+
 export function buildDesktopTrayItems(input: {
   status: DesktopUpdateStatus
   currentVersion: string

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,7 +20,7 @@ import { applyInitialWindowState } from './window-state.js'
 import { installDesktopBridge, resolveDesktopBridgeDir } from './desktop-host.js'
 import { watchProfileActivation } from './profile-watch.js'
 import updater from 'electron-updater'
-import { buildDesktopTrayItems, desktopUpdateChannel, desktopUpdatePrompt, publicDesktopUpdateError, type DesktopUpdateStatus } from './desktop-updater.js'
+import { buildDesktopTrayItems, desktopUpdateChannel, desktopUpdatePrompt, formatDesktopReleaseNotes, publicDesktopUpdateError, type DesktopUpdateStatus } from './desktop-updater.js'
 
 interface DshProcessModule {
   isApplyPluginUpdatesIpc: (message: unknown) => boolean
@@ -496,7 +496,7 @@ async function checkDesktopUpdate(): Promise<void> {
       })
       return
     }
-    updateStatus = { kind: 'available', version, releaseNotes: releaseNotesText(result?.updateInfo.releaseNotes) }
+    updateStatus = { kind: 'available', version, releaseNotes: formatDesktopReleaseNotes(result?.updateInfo.releaseNotes) }
     refreshTrayMenu()
     const prompt = await dialog.showMessageBox({
       type: 'question',
@@ -552,15 +552,6 @@ async function downloadDesktopUpdate(): Promise<void> {
 
 async function installDesktopUpdate(): Promise<void> {
   await shutdownDesktop(() => { autoUpdater.quitAndInstall(false, true) })
-}
-
-function releaseNotesText(notes: string | Array<{ note?: string | null }> | null | undefined): string | undefined {
-  if (typeof notes === 'string' && notes.trim() !== '') return notes.trim()
-  if (Array.isArray(notes)) {
-    const text = notes.map(item => item.note ?? '').join('\n').trim()
-    if (text !== '') return text
-  }
-  return undefined
 }
 
 function showMainWindow(): void {

--- a/test/desktop-updater.test.ts
+++ b/test/desktop-updater.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict'
 import { readFile } from 'node:fs/promises'
 import test from 'node:test'
 
-import { buildDesktopTrayItems, DESKTOP_UPDATE_WARNING, desktopUpdateChannel, desktopUpdatePrompt, publicDesktopUpdateError } from '../src/desktop-updater.js'
+import { buildDesktopTrayItems, DESKTOP_UPDATE_WARNING, desktopUpdateChannel, desktopUpdatePrompt, formatDesktopReleaseNotes, publicDesktopUpdateError } from '../src/desktop-updater.js'
 
 test('开发态和空闲态都提供手动检查，不自动下载', () => {
   const idle = buildDesktopTrayItems({ status: { kind: 'idle' }, currentVersion: '0.1.4', packaged: true })
@@ -38,6 +38,11 @@ test('更新说明描述桌面应用更新，不混用官方运行时警告', ()
   assert.match(text, /0\.1\.5/)
   assert.match(text, new RegExp(DESKTOP_UPDATE_WARNING))
   assert.match(text, /修复托盘/)
+})
+
+test('更新说明将 GitHub 的 HTML 和 Markdown 转为支持中英文的纯文本', () => {
+  const notes = formatDesktopReleaseNotes('<p><strong>更新说明</strong></p><ul><li>修复中文显示</li><li><a href="https://github.com/MichengAI/dsh-codex-desktop/compare/v1.0.13...v1.0.14">Full Changelog</a></li></ul>\n\n## English\n- [Install guide](https://example.com/install)')
+  assert.equal(notes, '更新说明\n- 修复中文显示\n- Full Changelog\nEnglish\n- Install guide: https://example.com/install')
 })
 
 test('macOS 更新通道按 CPU 架构隔离', () => {


### PR DESCRIPTION
## 变更
- 将 GitHub Release 的 HTML 与 Markdown 转换为原生提示框可读文本。
- 保留中英文、列表及链接信息。
- 递增桌面端版本至 1.0.15。

## 验证
- pnpm test